### PR TITLE
deploy-database_Setting-i18n_update

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,5 +50,6 @@ test:
 production:
   <<: *default
   database: freemarket_sample_61e_production
-  username: freemarket_sample_61e
-  password: <%= ENV['FREEMARKET_SAMPLE_61E_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql.sock

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
#what
・database.ymlの修正
・i18nの修正

#why
・本番環境でインストールするmysqlの設定とローカル環境の設定を合わせるため
・訳語が存在しないときのフォールバック動作を規定する設定に対しての対応
http://midnight-engineering.hatenadiary.jp/entry/2019/01/02/181645