### PR TITLE
capistrano-update

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,5 +1,7 @@
 require "capistrano/setup"
 require "capistrano/deploy"
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
 require 'capistrano/rbenv'
 require 'capistrano/bundler'
 require 'capistrano/rails/assets'


### PR DESCRIPTION
#what
Git SCMのプラグインを追加

#why
バージョンアップによるエラー対処のため、warningに従って記述
https://tackeyy.com/blog/posts/fix-capistrano-deprecation-notice-after-capistrano-version-up
