### PR TITLE
deploy-masterkey

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,6 +5,8 @@ set :application, "freemarket_sample_61e"
 set :repo_url, "git@github.com:junya30st/freemarket_sample_61e.git"
 
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/uploads')
+set :linked_files, fetch(:linked_files, []).push("config/master.key")
+
 
 set :rbenv_type, :user
 set :rbenv_ruby, '2.5.1'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
+  config.require_master_key = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.


### PR DESCRIPTION
#what
本番環境のshared/configにmaster.keyを作成
作成したmaster.keyを読み込まれるように記述を修正

#why
デプロイ中に接続拒否のエラーがでていたため