### PR TITLE
商品テーブルを修正しました

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ has_many :brands_groups
 |delivery_origin|string|null: false|
 |delivery_type|string|null: false|
 |schedule|string|null: false|
-|small_category_id|integer|null: false, forein_key: true|
+|category_id|integer|null: false, forein_key: true|
 |brand_id|integer|foreign_key: true|
 |user_id|integer|null: false, foreign_key: true|
 


### PR DESCRIPTION
# what
商品テーブルのカラムの修正

# why
昨日メンターのアドバイスでカテゴリーにancestryを導入しましたが、その結果カテゴリーテーブルが１つに統一され、小カテゴリーが消滅したのですが、商品テーブルの外部キーとしてのカラム名に小カテゴリーIDが残っていましたので、これをカテゴリーIDに変更しました