### PR TITLE
商品詳細ページにおけるその他商品表示の実装

### DIFF
--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -747,6 +747,7 @@
       height: 260px;
       margin: 0 calc(50% - 50vw);
       background-image: url("https://web-jp-assets.mercdn.net/_next/static/images/download_app_bg-b57d6f1a32f2aebd89cf6f43bc2e4b39.jpg");
+      background-size: cover;
 
       &__area {
         width: 750px;

--- a/app/assets/stylesheets/modules/_show.scss
+++ b/app/assets/stylesheets/modules/_show.scss
@@ -564,6 +564,14 @@
       }
     }
   }
+  .forth-box-none {
+    width: 700px;
+    font-size: 22px;
+    font-weight: 600;
+    text-align: center;
+    margin: 24px auto 0;
+    padding-bottom: 24px;
+  }
   .forth-box {
     width: 700px;
     margin: 24px auto 0;
@@ -587,6 +595,7 @@
       display: flex;
       flex-wrap: wrap;
       justify-content: space-between;
+      padding-bottom: 20px;
 
       .forth-box__body--content {
         height: 330px;
@@ -602,12 +611,9 @@
             overflow: hidden;
 
             img {
-              position: absolute;
-              left: 50%;
-              top: 50%;
               width: 100%;
-              height: auto;
-              transform: translate(-50%, -50%);
+              height: 100%;
+              object-fit: cover;
             }
           }
         }
@@ -618,6 +624,9 @@
           .forth-box__body--content--foot--detail--name {
             font-size: 16px;
             position: relative;
+            overflow: hidden;
+            height: 3em;
+            line-height: 1.5;
 
             .forth-box__body--content--foot--detail--name--hide {
               height: 25px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,6 +21,7 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.with_attached_images.find(params[:id])
+    @others = Item.where.not(id: @item.id).where(user_id: @item.user_id).where(process: "selling").order("created_at DESC").limit(6)
       if user_signed_in?
         if @item.user_id == current_user.id
           redirect_to myitem_path(@item.id)

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -191,13 +191,18 @@
         .third-box__foot--pinterest
           %i.fab.fa-pinterest
         
-  .forth-box
-    = link_to "" do
-      .forth-box__header
-        = @item.user.nickname
-        さんのその他の出品
-    .forth-box__body
-      = render "shared/other-user-items"
+  - if @others.present?
+    .forth-box
+      = link_to "" do
+        .forth-box__header
+          = @item.user.nickname
+          さんのその他の出品
+      .forth-box__body
+        = render "shared/other-user-items"
+  - else
+    .forth-box-none
+      = @item.user.nickname
+      さんのその他の出品はありません
 
 .background
   = render "shared/footer"

--- a/app/views/shared/_other-user-items.html.haml
+++ b/app/views/shared/_other-user-items.html.haml
@@ -1,96 +1,21 @@
-.forth-box__body--content
-  %a{href:""}
-    .forth-box__body--content--head
-      .forth-box__body--content--head--photo
-        = image_tag 'https://static.mercdn.net/thumb/photos/m79719340269_1.jpg?1572100350'
-    .forth-box__body--content--foot--detail
-      .forth-box__body--content--foot--detail--name
-        【お買い得】EIZO ショートブーツ
-        .forth-box__body--content--foot--detail--name--hide
-      .forth-box__body--content--foot--detail--bottom-bar
-        .forth-box__body--content--foot--detail--bottom-bar--price
-          ¥6,000
-        .forth-box__body--content--foot--detail--bottom-bar--good
-          %i.far.fa-heart
-          .forth-box__body--content--foot--detail--bottom-bar--good--content
-            2
-.forth-box__body--content
-  %a{href:""}
-    .forth-box__body--content--head
-      .forth-box__body--content--head--photo
-        = image_tag 'https://static.mercdn.net/thumb/photos/m79719340269_1.jpg?1572100350'
-    .forth-box__body--content--foot--detail
-      .forth-box__body--content--foot--detail--name
-        【お買い得】EIZO ショートブーツ
-        .forth-box__body--content--foot--detail--name--hide
-      .forth-box__body--content--foot--detail--bottom-bar
-        .forth-box__body--content--foot--detail--bottom-bar--price
-          ¥6,000
-        .forth-box__body--content--foot--detail--bottom-bar--good
-          %i.far.fa-heart
-          .forth-box__body--content--foot--detail--bottom-bar--good--content
-            2
-.forth-box__body--content
-  %a{href:""}
-    .forth-box__body--content--head
-      .forth-box__body--content--head--photo
-        = image_tag 'https://static.mercdn.net/thumb/photos/m79719340269_1.jpg?1572100350'
-    .forth-box__body--content--foot--detail
-      .forth-box__body--content--foot--detail--name
-        【お買い得】EIZO ショートブーツ
-        .forth-box__body--content--foot--detail--name--hide
-      .forth-box__body--content--foot--detail--bottom-bar
-        .forth-box__body--content--foot--detail--bottom-bar--price
-          ¥6,000
-        .forth-box__body--content--foot--detail--bottom-bar--good
-          %i.far.fa-heart
-          .forth-box__body--content--foot--detail--bottom-bar--good--content
-            2
-.forth-box__body--content
-  %a{href:""}
-    .forth-box__body--content--head
-      .forth-box__body--content--head--photo
-        = image_tag 'https://static.mercdn.net/thumb/photos/m79719340269_1.jpg?1572100350'
-    .forth-box__body--content--foot--detail
-      .forth-box__body--content--foot--detail--name
-        【お買い得】EIZO ショートブーツ
-        .forth-box__body--content--foot--detail--name--hide
-      .forth-box__body--content--foot--detail--bottom-bar
-        .forth-box__body--content--foot--detail--bottom-bar--price
-          ¥6,000
-        .forth-box__body--content--foot--detail--bottom-bar--good
-          %i.far.fa-heart
-          .forth-box__body--content--foot--detail--bottom-bar--good--content
-            2
-.forth-box__body--content
-  %a{href:""}
-    .forth-box__body--content--head
-      .forth-box__body--content--head--photo
-        = image_tag 'https://static.mercdn.net/thumb/photos/m79719340269_1.jpg?1572100350'
-    .forth-box__body--content--foot--detail
-      .forth-box__body--content--foot--detail--name
-        【お買い得】EIZO ショートブーツ
-        .forth-box__body--content--foot--detail--name--hide
-      .forth-box__body--content--foot--detail--bottom-bar
-        .forth-box__body--content--foot--detail--bottom-bar--price
-          ¥6,000
-        .forth-box__body--content--foot--detail--bottom-bar--good
-          %i.far.fa-heart
-          .forth-box__body--content--foot--detail--bottom-bar--good--content
-            2
-.forth-box__body--content
-  %a{href:""}
-    .forth-box__body--content--head
-      .forth-box__body--content--head--photo
-        = image_tag 'https://static.mercdn.net/thumb/photos/m79719340269_1.jpg?1572100350'
-    .forth-box__body--content--foot--detail
-      .forth-box__body--content--foot--detail--name
-        【お買い得】EIZO ショートブーツ
-        .forth-box__body--content--foot--detail--name--hide
-      .forth-box__body--content--foot--detail--bottom-bar
-        .forth-box__body--content--foot--detail--bottom-bar--price
-          ¥6,000
-        .forth-box__body--content--foot--detail--bottom-bar--good
-          %i.far.fa-heart
-          .forth-box__body--content--foot--detail--bottom-bar--good--content
-            2
+- @others.each do |other|
+  .forth-box__body--content
+    = link_to item_path(other.id) do
+      .forth-box__body--content--head
+        .forth-box__body--content--head--photo
+          - other.images.first(1).each do |image|
+            = image_tag image
+      .forth-box__body--content--foot--detail
+        .forth-box__body--content--foot--detail--name
+          = other.name
+          .forth-box__body--content--foot--detail--name--hide
+        .forth-box__body--content--foot--detail--bottom-bar
+          .forth-box__body--content--foot--detail--bottom-bar--price
+            ¥
+            = other.price
+          -# 条件分岐によりいいねが付いているもののみ表示するようにする
+          -# いいねテーブルをまだ作っていないため現状割愛
+          -# .forth-box__body--content--foot--detail--bottom-bar--good
+          -#   %i.far.fa-heart
+          -#   .forth-box__body--content--foot--detail--bottom-bar--good--content
+          -#     2


### PR DESCRIPTION
# What
商品詳細ページにおいて、その商品の出品者がその他に出品している商品があればそれを表示し、もしなければそれに対応したviewを表示できるようにした。

# Why
目に入る商品を少しでも増やすため。