### PR TITLE
購入後確認ページに住所の反映

### DIFF
--- a/app/views/transactions/result.html.haml
+++ b/app/views/transactions/result.html.haml
@@ -48,11 +48,12 @@
         .purchase__body__user__label-title
           配送先
         %address.purchase__body__user__label-address
-          〒150−0043
+          〒
+          = current_user.user_address.zip
           %br
-          東京都 渋谷区 道玄坂２丁目１０番１２号 新大宗ビル３号館８F
+          = current_user.user_address.city + current_user.user_address.town
           %br
-          真子　就有
+          = current_user.name_family_kanji + current_user.name_first_kanji
       
         
 


### PR DESCRIPTION
#what
商品購入後の確認ページ内の配送先に
ユーザーの住所が表示される様に修正